### PR TITLE
fix: bad voice states filtering

### DIFF
--- a/lib/src/services/music.dart
+++ b/lib/src/services/music.dart
@@ -306,12 +306,11 @@ class MusicService {
     /// Returns a list of members connected to the same voice channel as the
     /// [event] member. Excludes the bot, if present.
     bool hasConnectedMembers(IGuild iGuild) {
-      // the bot represents one of these voice states, so we subtract 1 and see
-      // if there are any other members connected
       final voiceStatesInChannel = iGuild.voiceStates.entries.where((element) {
-        return element.value.channel?.id == currentChannelId;
+        return element.value.channel?.id == currentChannelId &&
+            element.key != botMember.id;
       });
-      return (voiceStatesInChannel.length - 1) > 0;
+      return voiceStatesInChannel.isNotEmpty;
     }
 
     if (!hasConnectedMembers(guild)) {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

<!--- Describe your changes in detail -->

This version of the `hasConnectedMembers` function explicitly checks for the bot's voice state and excludes it from the count of connected members.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
